### PR TITLE
feat: add script for inserting 'use client' directive for Next.js App Router

### DIFF
--- a/packages/package-lock.json
+++ b/packages/package-lock.json
@@ -1,17 +1,20 @@
 {
   "name": "secptrum-ui",
-  "version": "1.1.32",
+  "version": "1.1.33-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "secptrum-ui",
-      "version": "1.1.32",
+      "version": "1.1.33-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
         "jwt-decode": "^4.0.0",
         "react-icons": "^5.3.0",
         "styled-chroma": "^0.1.61"
+      },
+      "bin": {
+        "insert-client": "scripts/insertUseClient.js"
       },
       "devDependencies": {
         "@rollup/plugin-babel": "^6.0.4",

--- a/packages/package.json
+++ b/packages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secptrum-ui",
-  "version": "1.1.32",
+  "version": "1.1.33-beta.1",
   "description": "**SecptrumUI** A React component library with adaptable, responsive designs using `styled-chroma`",
   "homepage": "https://secptrumui.vercel.app",
   "repository": {
@@ -28,11 +28,15 @@
   ],
   "scripts": {
     "build": "rollup -c",
+    "insert-client": "node scripts/insertUseClient.js",
     "postbuild": "copyfiles -u 1 src/types/**/* dist/",
     "prerelease": "npx tsc --noEmit",
     "release": "npm version patch && git push origin master --follow-tags",
     "release-org": "npm version patch && git push org-origin master --follow-tags",
     "typecheck": "tsc --noEmit"
+  },
+  "bin": {
+    "insert-client": "./scripts/insertUseClient.js"
   },
   "keywords": [
     "react",
@@ -71,6 +75,7 @@
     "rollup-plugin-peer-deps-external": "^2.2.4",
     "rollup-plugin-visualizer": "^5.12.0",
     "tslib": "^2.7.0",
-    "typescript": "^5.5.4"
+    "typescript": "^5.5.4",
+    "insert-client": "./scripts/insertUseClient.js"
   }
 }

--- a/packages/rollup.config.js
+++ b/packages/rollup.config.js
@@ -1,53 +1,54 @@
-import resolve from "@rollup/plugin-node-resolve";
-import commonjs from "@rollup/plugin-commonjs";
-import typescript from "@rollup/plugin-typescript";
-import babel from "@rollup/plugin-babel";
-import peerDepsExternal from "rollup-plugin-peer-deps-external";
-import pkg from "./package.json";
-import del from "rollup-plugin-delete";
-import terser from "@rollup/plugin-terser";
-import visualizer from "rollup-plugin-visualizer";
+import resolve from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+import typescript from '@rollup/plugin-typescript';
+import babel from '@rollup/plugin-babel';
+import peerDepsExternal from 'rollup-plugin-peer-deps-external';
+import pkg from './package.json';
+import del from 'rollup-plugin-delete';
+import terser from '@rollup/plugin-terser';
+import visualizer from 'rollup-plugin-visualizer';
 
 export default {
-  input: "src/index.ts", // Entry point for your library
+  input: 'src/index.ts', // Entry point for your library
   output: [
     {
       file: pkg.main,
-      format: "cjs", // CommonJS format
+      format: 'cjs', // CommonJS format
       sourcemap: true,
-      exports: "named",
+      exports: 'named',
     },
     {
       file: pkg.module,
-      format: "es", // ES module format
+      format: 'es', // ES module format
       sourcemap: true,
-      exports: "named",
+      exports: 'named',
     },
     {
       file: pkg.unpkg,
-      format: "umd", // UMD format for use in browsers
-      name: "SecptrumUI", // The global variable name for UMD builds
+      format: 'umd', // UMD format for use in browsers
+      name: 'SecptrumUI', // The global variable name for UMD builds
       globals: {
-        react: "React",
-        "react-dom": "ReactDOM",
-        "styled-chroma": "styled",
-        "react/jsx-runtime": "jsxRuntime",
+        react: 'React',
+        'react-dom': 'ReactDOM',
+        'styled-chroma': 'styled',
+        'react/jsx-runtime': 'jsxRuntime',
       },
       sourcemap: true,
     },
   ],
   plugins: [
-    del({ targets: "dist/*" }),
+    del({ targets: 'dist/*' }),
     peerDepsExternal(), // Automatically mark peer dependencies as external
     resolve(), // Helps Rollup find external modules
     commonjs(), // Converts CommonJS modules to ES6
     typescript({
-      tsconfig: "./tsconfig.json",
+      tsconfig: './tsconfig.json',
       outputToFilesystem: true,
-    }), // Transpile TypeScript files
+    }),
+
     babel({
-      exclude: "node_modules/**", // Only transpile our source code
-      babelHelpers: "bundled",
+      exclude: 'node_modules/**', // Only transpile our source code
+      babelHelpers: 'bundled',
     }),
 
     // Minify the output for production builds
@@ -62,8 +63,8 @@ export default {
         toplevel: true,
       },
     }),
-    visualizer({ open: true, filename: "bundle-analysis.html" }),
+    visualizer({ open: true, filename: 'bundle-analysis.html' }),
   ],
   // Prevent bundling of peer dependencies
-  external: ["react", "react-dom", "react/jsx-runtime"],
+  external: ['react', 'react-dom', 'react/jsx-runtime'],
 };

--- a/packages/scripts/insertUseClient.js
+++ b/packages/scripts/insertUseClient.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+// Ensure the path to the dist directory is correct
+const distDir = path.join(__dirname, '../dist');
+
+// Check if the directory exists
+if (fs.existsSync(distDir)) {
+  // Recursively add 'use client' directive to all relevant files in 'dist'
+  function addUseClientToFiles(dir) {
+    const files = fs.readdirSync(dir);
+
+    files.forEach((file) => {
+      const fullPath = path.join(dir, file);
+      const stat = fs.statSync(fullPath);
+
+      if (stat.isDirectory()) {
+        // Recursively check subdirectories
+        addUseClientToFiles(fullPath);
+      } else if (file.endsWith('.js') || file.endsWith('.ts')) {
+        // Read the file
+        const content = fs.readFileSync(fullPath, 'utf8');
+
+        // Check if 'use client' is already present
+        if (!content.startsWith('"use client";')) {
+          // Add 'use client' at the top
+          const newContent = `"use client";\n${content}`;
+
+          // Write the file back with 'use client' at the top
+          fs.writeFileSync(fullPath, newContent, 'utf8');
+          console.log(`Added 'use client' to: ${fullPath}`);
+        }
+      }
+    });
+  }
+
+  addUseClientToFiles(distDir);
+} else {
+  console.error(
+    `Directory ${distDir} does not exist. Make sure Rollup build was successful.`
+  );
+}

--- a/packages/src/components/Button/Button.tsx
+++ b/packages/src/components/Button/Button.tsx
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { forwardRef, useEffect, useState } from "react";
-import { AiOutlineLoading3Quarters } from "react-icons/ai";
-import Icon from "../Icon/Icon";
-import { ButtonProps } from "../../types/sui";
-import { ButtonSui } from "../../styles/action/styled";
-import { useTheme } from "styled-chroma";
+import { forwardRef, useEffect, useState } from 'react';
+import { AiOutlineLoading3Quarters } from 'react-icons/ai';
+import Icon from '../Icon/Icon';
+import { ButtonProps } from '../../types/sui';
+import { ButtonSui } from '../../styles/action/styled';
+import { useTheme } from 'styled-chroma';
 
 /**
  * A customizable button component designed to handle various actions and events in your application.
@@ -58,11 +58,11 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     {
       children,
       mode,
-      size = "md",
-      radius = "xl",
-      variant = "solid",
+      size = 'md',
+      radius = 'xl',
+      variant = 'solid',
       icon,
-      iconPosition = "left",
+      iconPosition = 'left',
       iconSize,
       ...props
     },
@@ -75,14 +75,14 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       if (mode) {
         setM(mode);
       } else {
-        setM(themeMode as ButtonProps["mode"]);
+        setM(themeMode as ButtonProps['mode']);
       }
     }, [mode, themeMode]);
 
     const getWidth = () => {
-      if (props.fullWidth) return "100%";
+      if (props.fullWidth) return '100%';
       if (props.width) return props.width;
-      return "fit-content";
+      return 'fit-content';
     };
 
     return (
@@ -104,11 +104,11 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         ) : (
           ((
             <>
-              {icon && iconPosition === "left" && (
+              {icon && iconPosition === 'left' && (
                 <Icon size={iconSize} icon={icon} />
               )}
               {children}
-              {icon && iconPosition === "right" && (
+              {icon && iconPosition === 'right' && (
                 <Icon size={iconSize} icon={icon} />
               )}
             </>
@@ -120,4 +120,4 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 );
 
 export default Button;
-Button.displayName = "Button";
+Button.displayName = 'Button';

--- a/packages/src/index.ts
+++ b/packages/src/index.ts
@@ -41,3 +41,6 @@ export { useAuth } from "./hooks/useAuth";
 export { default as AuthProvider } from "./hooks/useAuth";
 export { default as useNavigation } from "./hooks/useNavigation";
 export { default as ThemeProvider } from "./context/useTheme";
+
+// Types
+// export * from "./types/sui";


### PR DESCRIPTION
# Add script for inserting 'use client' directive for Next.js App Router

- Added `insertUseClient.js` script
- Updated `package.json`:
  - New `insert-client` npm script
  - `bin` entry for CLI usage
  - DevDependency for the script